### PR TITLE
clean up styles

### DIFF
--- a/client/web/css/global.css
+++ b/client/web/css/global.css
@@ -2,54 +2,31 @@
 * The CSS shown here will not be introduced in the Quickstart guide, but
 * shows how you can use CSS to style your Element's container.
 */
-input,
-.StripeElement {
-  height: 40px;
-  padding: 10px 12px;
-
-  color: #32325d;
-  background-color: white;
-  border: 1px solid transparent;
-  border-radius: 4px;
-
-  box-shadow: 0 1px 3px 0 #e6ebf1;
-  -webkit-transition: box-shadow 150ms ease;
-  transition: box-shadow 150ms ease;
-}
-
-input:focus,
-.StripeElement--focus {
-  box-shadow: 0 1px 3px 0 #cfd7df;
-}
-
-.StripeElement--invalid {
-  border-color: #fa755a;
-}
-
-.StripeElement--webkit-autofill {
-  background-color: #fefde5 !important;
-}
 
 /* Variables */
 :root {
   --body-color: rgb(247, 250, 252);
+  --font-color: rgb(50, 50, 93);
   --button-color: rgb(30, 166, 114);
-  --accent-color: #32325d;
-  --link-color: ##6b7c93;
-  --font-color: rgb(105, 115, 134);
-  --body-font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  --accent-color: rgb(50, 50, 93);
+  --link-color: rgb(107, 124, 147);
+  --error-color: rgb(250, 117, 90);
+  --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --radius: 6px;
   --form-width: 600px;
+  --gray-light: #ccc;
 }
 
 /* Base */
 * {
   box-sizing: border-box;
 }
+
 body {
   font-family: var(--body-font-family);
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
+  color: var(--font-color);
 }
 
 /* Layout */
@@ -80,47 +57,39 @@ body {
     0px 2px 5px 0px rgba(50, 50, 93, 0.1), 0px 1px 1.5px 0px rgba(0, 0, 0, 0.07);
 }
 
-.sr-field-error {
-  color: var(--font-color);
-  text-align: left;
-  font-size: 13px;
-  line-height: 17px;
-  margin-top: 12px;
+/* Inputs */
+input,
+.StripeElement {
+  height: 40px;
+  padding: 10px 12px;
+  color: #32325d;
+  background-color: white;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px 0 #e6ebf1;
+  -webkit-transition: box-shadow 150ms ease;
+  transition: box-shadow 150ms ease;
+  width: 100%;
+  outline: none;
 }
 
-/* Inputs */
-input[type="text"],
-input[type="email"] {
-  width: 100%;
-  outline: none;
+input:focus,
+.StripeElement--focus {
+  box-shadow: 0 1px 3px 0 #cfd7df;
 }
-.sr-input,
-input[type="text"] {
-  border: 1px solid var(--gray-border);
-  border-radius: var(--radius);
-  padding: 5px 12px;
-  height: 44px;
-  width: 100%;
-  outline: none;
-  transition: box-shadow 0.2s ease;
-  background: white;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
+
+.StripeElement--invalid {
+  border-color: var(--error-color);
 }
-.sr-input:focus,
-input[type="text"]:focus,
-button:focus,
-.focused {
-  box-shadow: 0 0 0 1px rgba(50, 151, 211, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.07),
-    0 0 0 4px rgba(50, 151, 211, 0.3);
-  outline: none;
-  z-index: 9;
+
+.StripeElement--webkit-autofill {
+  background-color: #fefde5 !important;
 }
-.sr-input::placeholder,
-input[type="text"]::placeholder {
-  color: var(--gray-light);
+
+input::placeholder {
+  color: #aab7c4 ;
 }
+
 .sr-result {
   height: 44px;
   -webkit-transition: height 1s ease;
@@ -195,6 +164,13 @@ button:disabled {
   cursor: none;
 }
 
+#button-text:not(.payment) span.payment {
+  display: none;
+}
+#button-text:not(.setup) span.setup {
+  display: none;
+}
+
 a {
   color: var(--link-color);
   text-decoration: underline;
@@ -209,6 +185,7 @@ a:active {
   filter: brightness(0.5);
 }
 
+
 /* Code block */
 code,
 pre {
@@ -216,10 +193,12 @@ pre {
   font-size: 12px;
 }
 
+
 /* Stripe Element placeholder */
 .sr-element {
   padding-top: 12px;
 }
+
 
 /* Responsiveness */
 @media (max-width: 720px) {
@@ -253,7 +232,8 @@ pre {
   }
 }
 
-/* todo: spinner/processing state, errors, animations */
+
+/* spinner/processing state, errors, animations */
 
 .spinner,
 .spinner:before,
@@ -324,6 +304,7 @@ pre {
   }
 }
 
+
 /* Animated form */
 
 .sr-root {
@@ -356,6 +337,38 @@ pre {
     opacity: 1;
     transform: scale(1);
   }
+}
+
+
+/* Form element styling */
+
+#bank-name + button {
+  margin-top: 12px;
+}
+
+#error-message {
+  margin-top: 12px;
+  text-align: center;
+  color: var(--error-color);
+}
+
+#bank-name {
+  margin-top: 8px;
+}
+
+#error-message,
+#bank-name {
+  min-height: 20px;
+  font-size: 14px;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: all 400ms cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+#error-message.visible,
+#bank-name.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 #mandate-acceptance {

--- a/client/web/script.js
+++ b/client/web/script.js
@@ -60,9 +60,23 @@ const setupElements = function() {
   // Custom styling can be passed to options when creating an Element
   const style = {
     base: {
-      // Add your base input styles here. For example:
-      fontSize: "16px",
-      color: "#32325d"
+      color: '#32325d',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      fontSmoothing: 'antialiased',
+      fontSize: '16px',
+      '::placeholder': {
+        color: '#aab7c4'
+      },
+      ':-webkit-autofill': {
+        color: '#32325d',
+      },
+    },
+    invalid: {
+      color: '#fa755a',
+      iconColor: '#fa755a',
+      ':-webkit-autofill': {
+        color: '#fa755a',
+      },
     }
   };
 


### PR DESCRIPTION
**Updated the styles:**
- consistent style/color for placeholder
- input fields have the same padding
- space for both Bank (and branch) name, as well as errors
- color of error message same as color of element border in case of error

Original:
![image](https://user-images.githubusercontent.com/98241/74790803-90a70800-526d-11ea-8867-d5b18393f749.png)

Updated:
![image](https://user-images.githubusercontent.com/98241/74790840-b16f5d80-526d-11ea-8441-8ec6cd727936.png)

r? @thorsten-stripe 